### PR TITLE
Ensure dimensions are the same before association

### DIFF
--- a/src/momgrid/classes.py
+++ b/src/momgrid/classes.py
@@ -415,7 +415,7 @@ class MOMgrid:
         return static_to_xesmf(self.to_xarray(), grid_type=grid_type)
 
     def associate(self, data):
-        return associate_grid_with_data(self.to_xarray(), data)
+        return associate_grid_with_data(self.to_xarray(), reset_nominal_coords(data))
 
     def generate_weights(self, dsout, grid_type=["t", "u", "v", "c"]):
         grid_type = list(grid_type) if not isinstance(grid_type, list) else grid_type

--- a/src/momgrid/util.py
+++ b/src/momgrid/util.py
@@ -63,6 +63,20 @@ def associate_grid_with_data(grid, data):
 
     ds = data if isinstance(data, xr.Dataset) else xr.Dataset({data.name: data})
 
+    # Check that dimensions are identical
+    exceptions = []
+    for dim in ["xh", "yh", "xq", "yq"]:
+        if dim in grid.variables and dim in ds.variables:
+            try:
+                assert np.array_equal(grid[dim].values, ds[dim].values), dim
+            except AssertionError as exc:
+                exceptions.append(dim)
+
+    if len(exceptions) > 0:
+        raise RuntimeError(
+            f"Cannot associate grid to data. Different dims: {exceptions}"
+        )
+
     processed = {}
 
     for var in ds.keys():


### PR DESCRIPTION
- Associating a grid to data when the dimensions are different can trigger an explosion in memory
- Added check that dimensions are the same
- Reset nominal coords of the data before calling the associate() method